### PR TITLE
feat: add podSecurityContext support to deployment

### DIFF
--- a/charts/streamvisor/templates/deployment.yaml
+++ b/charts/streamvisor/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       tolerations:
 {{ toYaml .Values.deployment.tolerations | indent 8 }}
     {{- end }}
+    {{- if .Values.deployment.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.deployment.podSecurityContext | indent 8 }}
+    {{- end }}
       terminationGracePeriodSeconds: {{ .Values.deployment.gracePeriod }}
       containers:
         - name: "{{ template "streamvisor.fullname" . }}"

--- a/charts/streamvisor/values.yaml
+++ b/charts/streamvisor/values.yaml
@@ -36,6 +36,8 @@ deployment:
   annotations: {}
   ## @param deployment.tolerations Tolerations for Streamvisor pod assignment
   tolerations: []
+  ## @param deployment.podSecurityContext Pod-level security context (e.g. fsGroup for volume permissions)
+  podSecurityContext: {}
   ## @param deployment.gracePeriod Seconds in which pod needs to terminate gracefully
   gracePeriod: 30
   resources:


### PR DESCRIPTION
Allows setting pod-level security context (e.g. fsGroup) which is required for persistence to work when the container runs as a non-root user.